### PR TITLE
UI fixes

### DIFF
--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1940,6 +1940,7 @@ select {
   width: 160px;
   color: var(--theme-color);
   background-color: var(--theme-bg-color);
+  user-select: none;
 }
 
 input[type = 'search']::-webkit-search-cancel-button{

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -2051,7 +2051,9 @@ hr {
   right: 0;
   bottom: 20px;
   left: 20px;
-  width: 40px
+  width: 40px;
+  user-select: none;
+  pointer-events: none;
 }
 
 .logo a {

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1250,6 +1250,7 @@ li img {
   width: 32px;
   height: 32px;
   margin-right: 15px;
+  user-select: none;
 }
 
 .centretext {

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1414,6 +1414,7 @@ li img {
   font-family: lato;
   font-size: 18px;
   color: var(--text-a-color);
+  user-select: none;
 }
 .tabs ul {
   list-style-type: none;

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1613,6 +1613,7 @@ li img {
 .content-section-title {
   color: var(--content-title-color);
   margin-bottom: 4px;
+  user-select: none;
 }
 
 .content-section ul {

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1669,6 +1669,7 @@ li img {
   align-items: center;
   height: 45px;
   min-width: 110px;
+  user-select: none;
 }
 
 .icone {

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -403,6 +403,10 @@ input[type=radio] + span {
 }
 
 /* BUTTON */
+button, .button{
+  user-select: none;
+}
+
 a.button {
   position: relative;
   left: 20px;

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -103,7 +103,7 @@ body {
 
 .dark-light {
   position: fixed;
-  bottom: 50px;
+  bottom: 20px;
   right: 30px;
   background-color: var(--dropdown-bg);
   box-shadow: -1px 3px 8px -1px rgba(0, 0, 0, 0.2);

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -1938,6 +1938,8 @@ select {
   font-weight: bold;
   height: 30px;
   width: 160px;
+  color: var(--theme-color);
+  background-color: var(--theme-bg-color);
 }
 
 input[type = 'search']::-webkit-search-cancel-button{

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -951,6 +951,7 @@ input {
   margin-top: 53px;
   width: 100%;
   color: #fff;
+  height: -webkit-fill-available;
 }
 
 .form-wrap a {
@@ -990,7 +991,7 @@ input {
   padding: 0 1em;
   background: var(--theme-bg-color);
   border-radius: 15px;
-  min-height: 530px;
+  min-height: 100%;
 }
 
 .help-action {
@@ -999,13 +1000,13 @@ input {
   text-align: center;
 }
 
-.form-wrap .tabs-content div[id$=tab-content] {
+.form-wrap .tabs-content div[id$=tab-content]:not(.active) {
   display: none;
 }
 
-.form-wrap .tabs-content .active {
+/* .form-wrap .tabs-content .active {
   display: block !important;
-}
+} */
 
 .form-wrap form .input {
     margin: 0;


### PR DESCRIPTION
Fala galera, tudo beleza?

Eu estava gerenciando os webapps padrão do biglinux e no tab de "WebApps Adicionados" o background não cobria toda a logo do biglunux na tela desse jeito

![image](https://github.com/biglinux/biglinux-webapps/assets/64273139/232f8799-2483-4c26-9fab-7f6d10a848bc)

E meu TOC ficava incomodado com isso

![image](https://github.com/biglinux/biglinux-webapps/assets/64273139/5c4d008c-d324-4ee7-93bc-c3837ef8b2e6)

Então eu fiz algumas alterações no css para o wrapper ocupar o espaço disponível dessa forma

![image](https://github.com/biglinux/biglinux-webapps/assets/64273139/4bf05ea1-a71c-4a85-afe2-dd82e91a2861)

Creio que essas alterações não afetem nada e nem causem bugs, pelos testes que fiz não notei nada de errado.

Aliás, aproveitando a deixa, eu percebi que no devtools do bigbashview não tem como separar o devtools, ou pelo menos o botão não fica no mesmo lugar que os outros navegadores, poderiam me ajudar com isso? É incrivelmente ruim debegar com o devtools na mesma janela que o conteúdo porque não fica no estado que os usuários costumam ver a aplicação.