### PR TITLE
Use flex on tabs

### DIFF
--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -995,7 +995,7 @@ input {
   padding: 0 1em;
   background: var(--theme-bg-color);
   border-radius: 15px;
-  min-height: 100%;
+  min-height: -webkit-fill-available;
 }
 
 .help-action {

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/css/style.css
@@ -952,7 +952,6 @@ input {
 /* USER (FORM WRAPPER) */
 .form-wrap {
   position: relative;
-  margin-top: 53px;
   width: 100%;
   color: #fff;
   height: -webkit-fill-available;
@@ -1403,9 +1402,6 @@ li img {
 /* breakpoints */
 /* selectors relative to radio inputs */
 .tabs {
-    left: 50%;
-    transform: translateX(-50%);
-    position: fixed;
     border-radius: 5px 5px 0 0;
     min-width: 100%;
     background-color: var(--tabs-bg-color);
@@ -2151,4 +2147,17 @@ hr {
 
 #backup-li, #restore-li, #add-li{
   border-bottom: 2px solid var(--border-color);
+}
+
+
+
+#content{
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#content .overflow-wrapper{
+  overflow-y: auto;
+  height: 100%;
 }

--- a/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/index.sh.htm
+++ b/biglinux-webapps/usr/share/bigbashview/bcc/apps/biglinux-webapps/index.sh.htm
@@ -54,7 +54,7 @@ echo -n '
         <div class="logo">
           <img src="icons/logo-big-trans-branco.png" alt="logo" class="logo-biglinux"/>
         </div>
-        <div class="user">
+        <div class="user" id="content">
           <!-- TABS -->
           <div class="tabs">
             <input type="radio" id="tab1" name="tab-control"/>
@@ -90,7 +90,8 @@ echo -n '
               <div class="indicator"></div>
             </div>
           </div>
-          <div class="form-wrap">
+          <div class="overflow-wrapper">
+            <div class="form-wrap">
 
               <!-- TABS CONTENT -->
             <div class="tabs-content">
@@ -1130,6 +1131,7 @@ echo -n '
               <!-- FIM TABS CONTENT WEBAPPBIG -->
 
             </div>
+          </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Resolvi um probleminha em que a barra de rolagem ficava metade atrás das tabs

Antes: 

![image](https://github.com/biglinux/biglinux-webapps/assets/64273139/d41ce276-581b-4ef1-9770-fe65d7412c50)


Depois: 

![image](https://github.com/biglinux/biglinux-webapps/assets/64273139/577d2c79-884d-47d0-920f-300e1fd6d164)

Também resolvi um probleminha de incompatibilidade com o modo gtk