### PR TITLE
🐛 fix: favicon icon bleed across webapps + entry duplication

### DIFF
--- a/crates/webapps-core/src/models/webapp/collection.rs
+++ b/crates/webapps-core/src/models/webapp/collection.rs
@@ -46,11 +46,86 @@ impl WebAppCollection {
         categorized
     }
 
+    /// Insert a webapp, replacing any existing entry that shares its `app_file`.
+    ///
+    /// `app_file` is the on-disk `.desktop` filename and the entry's unique key:
+    /// there is exactly one file per `app_file` on disk, so the collection must
+    /// hold at most one entry per `app_file` too. Pushing blindly let a second
+    /// save with the same `app_file` create a duplicate that rendered twice —
+    /// and because [`remove_by_file`](Self::remove_by_file) deletes *every*
+    /// match, removing one of the pair silently removed both. Replacing in place
+    /// preserves the invariant. Entries with an empty `app_file` (not yet
+    /// installed) are never collapsed together.
     pub fn add(&mut self, webapp: WebApp) {
+        if !webapp.app_file.is_empty() {
+            if let Some(existing) = self
+                .webapps
+                .iter_mut()
+                .find(|app| app.app_file == webapp.app_file)
+            {
+                *existing = webapp;
+                return;
+            }
+        }
         self.webapps.push(webapp);
     }
 
     pub fn remove_by_file(&mut self, app_file: &str) {
         self.webapps.retain(|app| app.app_file != app_file);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::WebApp;
+
+    fn app(app_file: &str, name: &str) -> WebApp {
+        WebApp {
+            app_file: app_file.to_string(),
+            app_name: name.to_string(),
+            ..WebApp::default()
+        }
+    }
+
+    #[test]
+    fn add_replaces_entry_with_same_app_file() {
+        let mut collection = WebAppCollection::default();
+        collection.add(app("brave-reddit-Default.desktop", "Reddit"));
+        collection.add(app("brave-reddit-Default.desktop", "Reddit Updated"));
+
+        assert_eq!(collection.webapps.len(), 1);
+        assert_eq!(collection.webapps[0].app_name, "Reddit Updated");
+    }
+
+    #[test]
+    fn add_keeps_distinct_app_files() {
+        let mut collection = WebAppCollection::default();
+        collection.add(app("a.desktop", "A"));
+        collection.add(app("b.desktop", "B"));
+
+        assert_eq!(collection.webapps.len(), 2);
+    }
+
+    #[test]
+    fn remove_by_file_after_duplicate_add_leaves_nothing_behind() {
+        // Before the dedup fix, two saves with the same app_file produced two
+        // entries and deleting one removed both. With dedup there is a single
+        // entry, so this just confirms removal is clean.
+        let mut collection = WebAppCollection::default();
+        collection.add(app("a.desktop", "A"));
+        collection.add(app("a.desktop", "A again"));
+        collection.remove_by_file("a.desktop");
+
+        assert!(collection.webapps.is_empty());
+    }
+
+    #[test]
+    fn add_never_collapses_empty_app_file_entries() {
+        let mut collection = WebAppCollection::default();
+        collection.add(app("", "Draft one"));
+        collection.add(app("", "Draft two"));
+
+        assert_eq!(collection.webapps.len(), 2);
     }
 }

--- a/crates/webapps-manager/src/favicon/mod.rs
+++ b/crates/webapps-manager/src/favicon/mod.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use std::path::PathBuf;
 
 use webapps_core::config;
+use webapps_core::desktop;
 
 pub struct SiteInfo {
     pub title: String,
@@ -24,7 +25,7 @@ pub fn fetch_site_info(url: &str) -> Result<SiteInfo> {
     let mut icon_candidates = html::extract_icon_candidates(&document, &normalized_url);
     icon_candidates.extend(fetch_manifest_icons(&client, &document, &normalized_url));
     html::sort_icon_candidates(&mut icon_candidates);
-    let cache_dir = ensure_favicon_cache()?;
+    let cache_dir = ensure_favicon_cache(&normalized_url)?;
     let icon_paths = download_icon_set(&client, &parsed, &cache_dir, &icon_candidates);
 
     Ok(SiteInfo { title, icon_paths })
@@ -84,8 +85,27 @@ fn fallback_title_from_host(parsed_url: &url::Url) -> String {
     }
 }
 
-fn ensure_favicon_cache() -> Result<PathBuf> {
-    let cache_dir = config::cache_dir().join("favicons");
+/// Per-site favicon cache directory.
+///
+/// Each detection writes its candidate icons as `icon_<index>.<ext>` with the
+/// index restarting at 0 for every site. A single flat directory shared across
+/// all sites meant a second site's detection overwrote the first site's
+/// `icon_0.png` — and since the dialog keeps that volatile cache path in
+/// `app_icon` until the user saves, the icon copied into the stable per-app path
+/// at save time could be the *other* site's image. That is a time-of-check /
+/// time-of-use race between "detect" and "save": persisting a stable copy didn't
+/// help because the source bytes were already clobbered. Namespacing the cache by
+/// the site's stable id (the same id used for the persisted icon and `.desktop`
+/// name) keeps each site's candidates in their own directory, so concurrent or
+/// interleaved detections can never clobber each other.
+fn favicon_cache_dir(url: &str) -> PathBuf {
+    config::cache_dir()
+        .join("favicons")
+        .join(desktop::desktop_file_id(url))
+}
+
+fn ensure_favicon_cache(url: &str) -> Result<PathBuf> {
+    let cache_dir = favicon_cache_dir(url);
     std::fs::create_dir_all(&cache_dir)?;
     Ok(cache_dir)
 }
@@ -213,5 +233,30 @@ fn download_google_favicon(
     let google_url = format!("https://www.google.com/s2/favicons?domain={host}&sz=256");
     if let Ok(path) = download::download_icon(client, &google_url, cache_dir, 100) {
         icon_paths.push(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn favicon_cache_dir_is_namespaced_per_site() {
+        // Two different sites must resolve to different cache directories so a
+        // detection for one can never overwrite the other's `icon_<index>` files.
+        let reddit = favicon_cache_dir("https://www.reddit.com/");
+        let loy = favicon_cache_dir("https://example.com/");
+
+        assert_ne!(reddit, loy);
+        assert!(reddit.ends_with("favicons/wwwredditcom"));
+        assert!(loy.ends_with("favicons/examplecom"));
+    }
+
+    #[test]
+    fn favicon_cache_dir_is_stable_for_same_site() {
+        assert_eq!(
+            favicon_cache_dir("https://example.com/"),
+            favicon_cache_dir("https://example.com/")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in the webapp manager that corrupt user data when adding webapps, both reproduced on a real profile (package 26.05.16 / testing):

1. **Favicon icon bleed** — detecting a favicon for one webapp overwrites another webapp's icon.
2. **Duplicate entries** — the same webapp gets listed twice, and deleting one removes both.

## 1. Favicon icon bleed (TOCTOU between detect and save)

Favicon detection downloads every site's candidate icons to a **shared** cache path `~/.cache/biglinux-webapps/favicons/icon_<N>.png`, with `N` restarting at 0 for every site. The dialog stores that volatile path in `app_icon`, and the copy to the stable per-app path (`persist_icon`) only runs **at save time**, reading whatever bytes are in `icon_0.png` at that moment.

So detecting a second site overwrites the first site's `icon_0.png`, and when the first webapp is saved the wrong image gets persisted. The earlier `persist_icon` change made the *destination* stable but left the *source* a shared, mutable file, so the bleed survived.

Evidence on disk: the Reddit entry's persisted icon (`webapp-wwwredditcom.png`) was byte-identical (md5) to the last-detected site's `icon_0.png`.

**Fix:** namespace the per-site favicon cache directory by `desktop_file_id` (`favicons/<id>/icon_<N>.png`) so detections of different sites can never clobber each other.

## 2. Duplicate entries

`WebAppCollection::add` pushed unconditionally, so a second save with the same `app_file` created a duplicate that rendered twice — and because `remove_by_file` deletes *every* match, removing one of the pair silently removed both.

**Fix:** `add` now replaces any existing entry that shares the same `app_file` in place; `app_file` is the on-disk `.desktop` filename and the entry's unique key. Drafts with an empty `app_file` are never collapsed.

## Tests

New unit tests for both fixes. Full workspace suite green: 164 passing, 0 failures.